### PR TITLE
Make this library cross-compile on 2.12 as well.

### DIFF
--- a/project/ScalaSettings.scala
+++ b/project/ScalaSettings.scala
@@ -4,18 +4,27 @@ import Keys._
 object ScalaSettings {
   type Sett = Def.Setting[_]
 
-  private val scala210or211 = Seq(
-    "-Yinline-warnings"
-  , "-feature"
-  , "-language:implicitConversions"
-  , "-language:higherKinds"
-  , "-language:postfixOps"
-  )
+  private def scalacOptionsVersion(scalaVersion: String): Seq[String] = {
+    Seq(
+      "-deprecation"
+      , "-unchecked"
+      , "-feature"
+      , "-language:implicitConversions"
+      , "-language:higherKinds"
+      , "-language:postfixOps"
+    ) ++ (CrossVersion.partialVersion(scalaVersion) match {
+      case Some((2, scalaMajor)) if scalaMajor <= 11 => Seq(
+        "-Yinline-warnings"
+        , "-optimise"
+      )
+      case _ => Seq.empty
+    })
+  }
 
   lazy val all: Seq[Sett] = Seq(
-    scalaVersion := "2.11.2"
-  , crossScalaVersions := Seq("2.11.2", "2.10.4")
-  , scalacOptions in Compile ++=  Seq("-deprecation", "-unchecked", "-optimise") ++ scala210or211
-  , scalacOptions in Test ++= Seq("-deprecation", "-unchecked", "-optimise") ++ scala210or211
+    scalaVersion := "2.12.3"
+  , crossScalaVersions := Seq("2.12.3", "2.11.11", "2.10.6")
+  , scalacOptions in Compile ++= scalacOptionsVersion(scalaVersion.value)
+  , scalacOptions in Test ++= scalacOptionsVersion(scalaVersion.value)
   )
 }

--- a/project/build.scala
+++ b/project/build.scala
@@ -12,10 +12,10 @@ object build extends Build {
     , organization := "com.nicta"
   )
 
-  val scalaz          = "org.scalaz"       %% "scalaz-core"               % "7.1.0"
-  val scalazEffect    = "org.scalaz"       %% "scalaz-effect"             % "7.1.0"
-  val scalazCheck     = "org.scalaz"       %% "scalaz-scalacheck-binding" % "7.1.0"    % "test"
-  val specs2          = "org.specs2"       %% "specs2"                    % "2.4"      % "test"
+  val scalaz          = "org.scalaz"       %% "scalaz-core"               % "7.2.15"
+  val scalazEffect    = "org.scalaz"       %% "scalaz-effect"             % "7.2.15"
+  val scalazCheck     = "org.scalaz"       %% "scalaz-scalacheck-binding" % "7.2.15"    % "test"
+  val specs2          = "org.specs2"       %% "specs2-core"               % "3.9.5"      % "test"
 
   val rng = Project(
     id = "rng"

--- a/project/build.scala
+++ b/project/build.scala
@@ -12,17 +12,22 @@ object build extends Build {
     , organization := "com.nicta"
   )
 
-  val scalaz          = "org.scalaz"       %% "scalaz-core"               % "7.2.15"
-  val scalazEffect    = "org.scalaz"       %% "scalaz-effect"             % "7.2.15"
-  val scalazCheck     = "org.scalaz"       %% "scalaz-scalacheck-binding" % "7.2.15"    % "test"
-  val specs2          = "org.specs2"       %% "specs2-core"               % "3.9.5"      % "test"
+  val scalazVersion = "7.2.15"
+  val specs2Version = "3.9.5"
+
+  val scalaz          = "org.scalaz"       %% "scalaz-core"               % scalazVersion
+  val scalazEffect    = "org.scalaz"       %% "scalaz-effect"             % scalazVersion
+  val scalazCheck     = "org.scalaz"       %% "scalaz-scalacheck-binding" % scalazVersion    % "test"
+  val specs2          = "org.specs2"       %% "specs2-core"               % specs2Version    % "test"
+  val specs2Check     = "org.specs2"       %% "specs2-scalacheck"         % specs2Version    % "test"
+  val scalaCheck      = "org.scalacheck"   %% "scalacheck"                % "1.13.4"         % "test"
 
   val rng = Project(
     id = "rng"
   , base = file(".")
   , settings = base ++ ReplSettings.all ++ releaseSettings ++ PublishSettings.all ++ InfoSettings.all ++ Seq[Sett](
       name := "rng"
-    , libraryDependencies ++= Seq(scalaz, scalazEffect, scalazCheck, specs2)
+    , libraryDependencies ++= Seq(scalaz, scalazEffect, scalazCheck, specs2, specs2Check, scalaCheck)
     ) ++
     net.virtualvoid.sbt.graph.Plugin.graphSettings ++
     sonatypeSettings

--- a/src/main/scala/com/nicta/rng/Rng.scala
+++ b/src/main/scala/com/nicta/rng/Rng.scala
@@ -89,6 +89,9 @@ sealed trait Rng[A] {
   def fill(n: Int): Rng[List[A]] =
     sequence(List.fill(n)(this))
 
+  def fillIList(n: Int): Rng[IList[A]] =
+    sequence(IList.fill(n)(this))
+
   def list(s: Size): Rng[List[A]] =
     for {
       n <- s.value match {
@@ -105,7 +108,7 @@ sealed trait Rng[A] {
              case None => int
              case Some(y) => chooseint(0, y)
            }
-      a <- fill(n)
+      a <- fillIList(n)
     } yield nel(z, a)
 
   def vector(s: Size): Rng[Vector[A]] =
@@ -312,7 +315,7 @@ object Rng {
     numerics1(z) map (_.toList.mkString)
 
   def alphanumericstring(z: Size): Rng[String] =
-    alphanumerics(z) map (_.mkString)
+    alphanumerics(z) map (_.toList.mkString)
 
   def alphanumericstring1(z: Size): Rng[String] =
     alphanumerics1(z) map (_.toList.mkString)
@@ -321,7 +324,7 @@ object Rng {
     for {
       a <- alpha
       b <- alphanumerics(if(z exists (_ < 1)) z.inc else z.dec)
-    } yield nel(a, b)
+    } yield nel(a, IList.fromList(b))
 
   def identifierstring(z: Size): Rng[String] =
     identifier(z) map (_.toList.mkString)
@@ -330,7 +333,7 @@ object Rng {
     for {
       a <- upper
       b <- lowers(if(z exists (_ < 1)) z.inc else z.dec)
-    } yield nel(a, b)
+    } yield nel(a, IList.fromList(b))
 
   def propernounstring(z: Size): Rng[String] =
     propernoun(z) map (_.toList.mkString)
@@ -416,8 +419,8 @@ object Rng {
       if(n <= q)
         r
       else l.tail match {
-        case Nil => r
-        case e::es => pick(n - q, nel(e, es))
+        case INil() => r
+        case ICons(e, es) => pick(n - q, nel(e, es))
       }
     }
 

--- a/src/test/scala/com/nicta/rng/RngSpec.scala
+++ b/src/test/scala/com/nicta/rng/RngSpec.scala
@@ -8,7 +8,7 @@ object RngSpec extends test.Spec {
 
   "Rng" should {
     "satisfy monad laws" ! monad.laws[Rng]
-  }; endp
+  }
 
   "chooseint must return a value between low and high" >> prop { (low: Int, high: Int) =>
     Rng.chooseint(low, high) must beBoundedBy(low, high)
@@ -39,7 +39,7 @@ object RngSpec extends test.Spec {
   }
 
   "oneofL distribution must be more or less uniform" >> {
-    Rng.oneofL(NonEmptyList.nel(0, 1.to(99).toList)) must beUniform
+    Rng.oneofL(NonEmptyList.nel(0, IList(1.to(99):_*))) must beUniform
   }
 
   "oneof distribution must be more or less uniform" >> {

--- a/src/test/scala/com/nicta/rng/test/RngArbitraries.scala
+++ b/src/test/scala/com/nicta/rng/test/RngArbitraries.scala
@@ -8,7 +8,7 @@ import org.scalacheck.{Gen, Arbitrary}, Arbitrary.arbitrary, Gen.{frequency, one
 trait RngArbitraries {
 
   implicit def RngIntArbitrary: Arbitrary[Rng[Int]] =
-    Arbitrary(Gen.parameterized(params => Gen.const(Rng.setseed(params.rng.nextInt) >> Rng.int)))
+    Arbitrary(Arbitrary.arbitrary[Int].map(seed => Rng.setseed(seed) >> Rng.int))
 
   implicit def RngIntFunctionArbitrary: Arbitrary[Rng[Int => Int]] =
     Arbitrary(Gen.parameterized(params => Gen.const(Rng.int.function[Int](CoRng(_ * _)))))


### PR DESCRIPTION
Library seems to compile on all three versions.

I've tried to fix the tests, they compile, but there seems to be a runtime library version mismatch which I am not able to pinpoint.

When running `+test` I get:

```
Exception in thread "specs2.fixed.env1590660034-8" java.lang.NoSuchMethodError: org.scalacheck.Arbitrary$.arbFunction1(Lorg/scalacheck/Arbitrary;)Lorg/scalacheck/Arbitrary;
        at scalaz.scalacheck.ScalazProperties$apply$.$anonfun$laws$32(ScalazProperties.scala:163)
        at scalaz.scalacheck.ScalazProperties$apply$.$anonfun$laws$32$adapted(ScalazProperties.scala:162)
        at scalaz.scalacheck.ScalazProperties$.scalaz$scalacheck$ScalazProperties$$newProperties(ScalazProperties.scala:14)
        at scalaz.scalacheck.ScalazProperties$apply$.laws(ScalazProperties.scala:162)
        at scalaz.scalacheck.ScalazProperties$applicative$.$anonfun$laws$34(ScalazProperties.scala:184)
        at scalaz.scalacheck.ScalazProperties$applicative$.$anonfun$laws$34$adapted(ScalazProperties.scala:183)
        at scalaz.scalacheck.ScalazProperties$.scalaz$scalacheck$ScalazProperties$$newProperties(ScalazProperties.scala:14)
        at scalaz.scalacheck.ScalazProperties$applicative$.laws(ScalazProperties.scala:183)
        at scalaz.scalacheck.ScalazProperties$monad$.$anonfun$laws$44(ScalazProperties.scala:233)
        at scalaz.scalacheck.ScalazProperties$monad$.$anonfun$laws$44$adapted(ScalazProperties.scala:232)
        at scalaz.scalacheck.ScalazProperties$.scalaz$scalacheck$ScalazProperties$$newProperties(ScalazProperties.scala:14)
        at scalaz.scalacheck.ScalazProperties$monad$.laws(ScalazProperties.scala:232)
        at com.nicta.rng.RngSpec$.$anonfun$new$2(RngSpec.scala:10)
```